### PR TITLE
Add single select update update capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Possible inputs:
 |update-field| **Required**. The field you want to update. This can be the Title, a Custom field, etc. Case-sensitive.|
 |update-value|**Required**. The new value you want to set. For example you can update a date fields to this new value.|
 |filter-field|**Optional**. This is the field we'll look at for each item in the project, and check if it meets the condition. If this field is left empty, we'll assume you're not filtering for specific items, and we'll update all items in the project.|
-|conditional|**Optional**. Compares the value of an item's field to the `filter-value` (e.g. <). See [supported field types](#suported-field-types) for more information on what's available|
+|conditional|**Optional**. Compares the value of an item's field to the `filter-value` (e.g. <). See [supported field types](#supported-field-types) for more information on what's available|
 |filter-value|**Optional**. The value you want to filter items on|
 |org|**Optional**. The organization/user that holds your project. By default we'll take the org/user that your Action is in (i.e. based on the repository from which it's called)|
 
@@ -51,10 +51,29 @@ To update items, you can use the following field types and their corresponding f
 - Text (including the Title)
 - Date
 - Number
+- Single Select
 
 <!-- NOTE: Labels and PRs. For these specific field types, you'll have to check the OAuth permissions for the organization you're connecting to. If restrictions are in place, data access to third parties will be limited, including this Action.
 
 This happens because the Labels and PRs are object that exist outside of the Project.   -->
+
+## More Examples
+
+````yaml
+- uses: eldrick19/bulk-project-update@main
+  with:
+    token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+    project-number: 123
+    org: my-org
+    update-field: Status
+    update-value: "Updated"
+    filter-field: Date
+    conditional: ==
+    filter-value: "2022-01-01"
+````
+
+^ Updates the "Status" field to "Updated" for all items with a "Date" field that is equal to "2022-01-01"
+
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,6 @@ inputs:
 
   conditional:
     description: "The conditional to be used to filter"
-    default: "=="
     required: false
 
   filter-value:

--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ def main():
     # If the field type is a single select, we need to change the field type to singleSelectOptionId and get the option ID
     if update['field_type'] == 'single_select':
         update['field_type'] = 'singleSelectOptionId'
-        update['field_value'] = helpers.get_option_id(data, update_field, update_value)
+        update['field_value'] = '"' + helpers.get_option_id(data, update_field, update_value) + '"'
     # If the field type is not a number, we need to wrap the value in quotes
     elif update['field_type'] != 'number':
         update['field_value'] = '"' + update_value + '"'

--- a/main.py
+++ b/main.py
@@ -44,26 +44,26 @@ def main():
     # Get the data from the project
     print('Fetching project data using the API...')
     project_id, data = helpers.get_project_data(
-        org, 
-        project_number, 
+        org,
+        project_number,
         token
     )
-    
+
     # Apply filters (if they exist)
     item_ids, item_names = helpers.filter_items_to_update(
-        data, 
-        filter_field, 
-        conditional, 
+        data,
+        filter_field,
+        conditional,
         filter_value
     )
-    
+
     # Output to Actions Workflow
     # Commenting this out for now, in a future version we'll use this to output the items to update to the workflow or to a JSON file
     # name = 'items_to_update'
     # value = item_ids
     # with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
     #     print(f'{name}={value}', file=fh)
-    
+
     # Set up update data
     update = {
         "project_id": project_id,
@@ -86,7 +86,7 @@ def main():
     for item in item_ids:
         update['item_id'] = item
         helpers.update_item(update, token)
-    
+
     # Print success message
     if len(item_ids) == 0:
         print("No items to update! 🤷‍♂️")

--- a/main.py
+++ b/main.py
@@ -69,12 +69,16 @@ def main():
         "project_id": project_id,
         "field_id": helpers.get_filter_field_parameter(data, update_field, 'id'),
         "field_type": helpers.get_filter_field_parameter(data, update_field, 'dataType').lower(), # We need to convert to lower case for the GraphQL mutation, since the field type is all caps
+        "field_value": update_value
     }
 
-    # Set the update value. If the field type is a number, we won't need to wrap the value in quotes
-    if update['field_type'] == 'number':
-        update['field_value'] = update_value
-    else:
+    # Do some data cleanup.
+    # If the field type is a single select, we need to change the field type to singleSelectOptionId and get the option ID
+    if update['field_type'] == 'single_select':
+        update['field_type'] = 'singleSelectOptionId'
+        update['field_value'] = helpers.get_option_id(data, update_field, update_value)
+    # If the field type is not a number, we need to wrap the value in quotes
+    elif update['field_type'] != 'number':
         update['field_value'] = '"' + update_value + '"'
 
     # Loop through each item and update it

--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ def main():
     filter_field = os.environ.get("INPUT_FILTER-FIELD")
 
     conditional = os.environ.get("INPUT_CONDITIONAL")
+    print("Conditional: " + conditional)
 
     filter_value = os.environ.get("INPUT_FILTER-VALUE")
 

--- a/main.py
+++ b/main.py
@@ -38,7 +38,6 @@ def main():
     filter_field = os.environ.get("INPUT_FILTER-FIELD")
 
     conditional = os.environ.get("INPUT_CONDITIONAL")
-    print("Conditional: " + conditional)
 
     filter_value = os.environ.get("INPUT_FILTER-VALUE")
 

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -51,7 +51,23 @@ def get_filter_field_parameter(data, input_field_name, parameter):
                 if item['field']['name'] == input_field_name:
                     filter_field_paramater = item['field'][parameter]
                     break
+
     return filter_field_paramater
+
+# Function that gets the option id for a single select field given the input field name and option name
+def get_option_id(data, input_field_name, option_name):
+    option_id = ''
+    for node in data:
+        item_fields = node['fieldValues']['nodes']
+        for item in item_fields:
+            if item and item['field'] and item['field']['name']:
+                if item['field']['name'] == input_field_name:
+                    for option in item['labels']['edges']:
+                        if option['node']['name'] == option_name:
+                            option_id = option['node']['id']
+                            break
+    return option_id
+    
 
 # ---- QUERY FUNCTIONS ----
 

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -62,9 +62,9 @@ def get_option_id(data, input_field_name, option_name):
         for item in item_fields:
             if item and item['field'] and item['field']['name']:
                 if item['field']['name'] == input_field_name:
-                    for option in item['labels']['edges']:
-                        if option['node']['name'] == option_name:
-                            option_id = option['node']['id']
+                    for option in options:
+                        if option['name'] == option_name:
+                            option_id = option['id']
                             break
     return option_id
     
@@ -109,6 +109,10 @@ def get_project_data(org, project_number, token):
                               id
                               name
                               dataType
+                              options {
+                                id
+                                name
+                              }
                             }
                           }
                         }

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -62,7 +62,7 @@ def get_option_id(data, input_field_name, option_name):
         for item in item_fields:
             if item and item['field'] and item['field']['name']:
                 if item['field']['name'] == input_field_name:
-                    for option in options:
+                    for option in item['field']['options']:
                         if option['name'] == option_name:
                             option_id = option['id']
                             break

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -16,7 +16,6 @@ def filter_items_to_update(data, filter_field, conditional, filter_value):
     # Otheriwse, filter the items
     else:
       print("Filtering items to update...")
-      print(conditional, filter_value)
       for node in data:
         item_fields = node['fieldValues']['nodes']
         for item in item_fields:

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -16,6 +16,7 @@ def filter_items_to_update(data, filter_field, conditional, filter_value):
     # Otheriwse, filter the items
     else:
       print("Filtering items to update...")
+      print(conditional, filter_value)
       for node in data:
         item_fields = node['fieldValues']['nodes']
         for item in item_fields:

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -27,6 +27,7 @@ def filter_items_to_update(data, filter_field, conditional, filter_value):
                         case [('TEXT' | 'TITLE' ), ('==' | '!=')]:
                             exec("if item['text'] " + conditional + " '" + filter_value + "':\n\titem_ids.append(node['id'])")
                         case [('NUMBER'), ('==' | '!=' | '<' | '<=' | '>' | '>=')]:
+                            print(conditional, filter_value)
                             exec("if item['number'] " + conditional + " " + filter_value + ":\n\titem_ids.append(node['id'])")
                         case _:
                             print("Conditional not supported. Please check the action inputs.")

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -27,7 +27,6 @@ def filter_items_to_update(data, filter_field, conditional, filter_value):
                         case [('TEXT' | 'TITLE' ), ('==' | '!=')]:
                             exec("if item['text'] " + conditional + " '" + filter_value + "':\n\titem_ids.append(node['id'])")
                         case [('NUMBER'), ('==' | '!=' | '<' | '<=' | '>' | '>=')]:
-                            print(conditional, filter_value)
                             exec("if item['number'] " + conditional + " " + filter_value + ":\n\titem_ids.append(node['id'])")
                         case _:
                             print("Conditional not supported. Please check the action inputs.")


### PR DESCRIPTION
This PR adds the ability to update a [single select field](https://docs.github.com/en/issues/planning-and-tracking-with-projects/understanding-fields/about-single-select-fields). 

If for example you want to update fields `Status` to `!`, given `Status` is a single select field, you can now do so